### PR TITLE
Add gui

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 *.pptx
 *.html
+*.pyc

--- a/README.md
+++ b/README.md
@@ -12,7 +12,8 @@ and writes the result back into the PowerPoint file.
 
 | File | Purpose |
 |---|---|
-| `generate_alt_text.py` | Main script |
+| `generate_alt_text.py` | Core script (also usable as a CLI) |
+| `gui.py` | Desktop GUI front-end (CustomTkinter) |
 | `geckodriver.exe` | Firefox WebDriver (pre-bundled for Windows) |
 
 ---
@@ -31,7 +32,7 @@ Download from [python.org](https://www.python.org/downloads/) and make sure
 Install all required packages with one command:
 
 ```
-pip install selenium python-pptx Pillow cairosvg
+pip install selenium python-pptx Pillow cairosvg customtkinter
 ```
 
 | Package | Version tested | Purpose |
@@ -40,6 +41,7 @@ pip install selenium python-pptx Pillow cairosvg
 | `python-pptx` | any recent | Read/write `.pptx` files |
 | `Pillow` | any recent | Convert BMP/TIFF/EMF/WMF images to PNG |
 | `cairosvg` | any recent | Convert SVG images to PNG |
+| `customtkinter` | any recent | Desktop GUI (`gui.py` only) |
 
 > **`cairosvg`** is optional — the script still works without it, but SVG
 > shapes will fail with a descriptive error message rather than being skipped
@@ -78,7 +80,7 @@ University of Michigan (or affiliated institution) Google account.
 2. **Install Python packages:**
 
    ```
-   pip install selenium python-pptx Pillow
+   pip install selenium python-pptx Pillow cairosvg customtkinter
    ```
 
 3. **Verify geckodriver** (Firefox only):
@@ -90,6 +92,28 @@ University of Michigan (or affiliated institution) Google account.
 ---
 
 ## Usage
+
+### GUI (recommended)
+
+```
+python gui.py
+```
+
+A desktop window opens with all options available as form controls.
+
+1. **Select input PPTX** — use the Browse button or type a path. The output
+   path is filled in automatically as `<name>_alt_text.pptx`.
+2. **Adjust options** — alt text version, browser, purpose, tone, include
+   checkboxes. The Geckodriver path field under Advanced (Firefox only) can be
+   left blank if `geckodriver.exe` is in the same folder as the script — it is
+   detected automatically.
+3. **Click Run.** The browser opens; sign in with your institutional Google
+   account. Progress streams into the Log area in real time.
+4. **Click Stop** (red button) at any time to abort after the current image
+   finishes. Slides processed so far are saved to the output file.
+5. **Clear** the Log area with the Clear button above it.
+
+### Command line
 
 ```
 python generate_alt_text.py <input.pptx> [options]
@@ -125,7 +149,7 @@ python generate_alt_text.py slides.pptx
 | `--output` | `-o` | `<stem>_alt_text.pptx` | Output file path |
 | `--version` | `-v` | `long` | Which alt text length to embed: `short` (≈ 1 sentence), `medium` (≈ 2–3 sentences), or `long` (full description) |
 | `--browser` | `-b` | `auto` | Browser to use. `auto` tries Firefox → Chrome → Edge |
-| `--geckodriver` | `-g` | `geckodriver.exe` in script folder | Path to `geckodriver` executable (Firefox only) |
+| `--geckodriver` | `-g` | `geckodriver.exe` in script folder | Path to `geckodriver` executable (Firefox only). Can be omitted if `geckodriver.exe` is in the same folder as the script — it is detected automatically. |
 | `--purpose` | `-p` | *(none)* | Purpose/Use Case radio button — see table below |
 | `--include` | `-i` | *(none)* | Checkboxes to tick — can be repeated |
 | `--tone` | `-t` | *(none)* | Tone of the generated alt text — see table below |

--- a/README.md
+++ b/README.md
@@ -101,17 +101,35 @@ python gui.py
 
 A desktop window opens with all options available as form controls.
 
-1. **Select input PPTX** — use the Browse button or type a path. The output
+1. **Browser launches automatically.** When the GUI starts it opens a browser
+   window and navigates to the tool. The Browser status row shows
+   *"Launching browser…"* then *"Waiting for sign-in…"*.
+
+2. **Sign in.** Complete the Google authentication in the browser window. Once
+   your profile is detected the status changes to *"Signed in ✓"* and the
+   Run button becomes available. You only need to sign in once per session.
+
+3. **Select input PPTX** — use the Browse button or type a path. The output
    path is filled in automatically as `<name>_alt_text.pptx`.
-2. **Adjust options** — alt text version, browser, purpose, tone, include
+
+4. **Adjust options** — alt text version, browser, purpose, tone, include
    checkboxes. The Geckodriver path field under Advanced (Firefox only) can be
    left blank if `geckodriver.exe` is in the same folder as the script — it is
    detected automatically.
-3. **Click Run.** The browser opens; sign in with your institutional Google
-   account. Progress streams into the Log area in real time.
-4. **Click Stop** (red button) at any time to abort after the current image
+
+5. **Click Run.** Processing starts immediately using the existing browser
+   session. Progress streams into the Log area in real time. When the run
+   finishes you can load another PPTX and click Run again without signing in
+   again.
+
+6. **Click Stop** (red button) at any time to abort after the current image
    finishes. Slides processed so far are saved to the output file.
-5. **Clear** the Log area with the Clear button above it.
+
+7. **Clear** the Log area with the Clear button above it.
+
+8. **Reconnect** — if the browser window is closed or the session is lost, the
+   status updates to *"Connection lost"*. Click Reconnect to launch a new
+   browser and sign in again.
 
 ### Command line
 

--- a/generate_alt_text.py
+++ b/generate_alt_text.py
@@ -357,10 +357,13 @@ def build_driver(browser: str, geckodriver_path: Path | None) -> webdriver.Remot
     )
 
 
-def wait_for_auth(driver: webdriver.Firefox, url: str) -> None:
+def wait_for_auth(driver: webdriver.Firefox, url: str, raise_on_timeout: bool = False) -> None:
     """
     Navigate to the tool and block until the user has authenticated.
     Authentication is confirmed when the profile link appears in the header.
+
+    When raise_on_timeout is True, raises TimeoutError instead of calling
+    sys.exit (used by the GUI so it can handle the failure gracefully).
     """
     print(f"\nOpening browser → {url}")
     driver.get(url)
@@ -374,6 +377,8 @@ def wait_for_auth(driver: webdriver.Firefox, url: str) -> None:
             EC.presence_of_element_located((By.CSS_SELECTOR, 'a[href="/profile"]'))
         )
     except TimeoutException:
+        if raise_on_timeout:
+            raise TimeoutError("Timed out waiting for authentication.")
         driver.quit()
         sys.exit("Timed out waiting for authentication. Please re-run the script.")
 
@@ -568,18 +573,21 @@ def upload_and_generate(
 
 # ── orchestration ─────────────────────────────────────────────────────────────
 
-def process_presentation(
+def run_batch(
+    driver: webdriver.Remote,
     pptx_path: Path,
     output_path: Path,
     tool_url: str,
     version: str,
-    browser: str,
-    geckodriver_path: Path | None,
     purpose: str | None,
     includes: list[str],
     tone: str | None,
     stop_event: threading.Event | None = None,
 ) -> None:
+    """
+    Process a presentation using an already-authenticated driver.
+    The caller is responsible for browser lifecycle (build_driver / driver.quit).
+    """
     prs = Presentation(pptx_path)
 
     # Collect all picture shapes up front so we can show progress
@@ -595,64 +603,56 @@ def process_presentation(
 
     print(f"Found {len(images)} picture(s) across {len(prs.slides)} slide(s).")
 
-    driver = build_driver(browser, geckodriver_path)
+    ok = 0
+    skipped = 0
+    errors = 0
 
-    try:
-        wait_for_auth(driver, tool_url)
+    for idx, (slide_num, shape) in enumerate(images, start=1):
+        if stop_event and stop_event.is_set():
+            print("\nAborted by user.\n")
+            break
 
-        ok = 0
-        skipped = 0
-        errors = 0
+        image = shape.image
+        ct = image.content_type.lower()
 
-        for idx, (slide_num, shape) in enumerate(images, start=1):
-            if stop_event and stop_event.is_set():
-                print("\nAborted by user.\n")
-                break
+        print(f"[{idx}/{len(images)}] Slide {slide_num} — {shape.name!r} ({ct})")
 
-            image = shape.image
-            ct = image.content_type.lower()
+        # Save image to a temp file (converts raster and vector formats to PNG as needed)
+        tmp_path = None
+        try:
+            tmp_path = save_image_to_temp(image.blob, ct)
 
-            print(f"[{idx}/{len(images)}] Slide {slide_num} — {shape.name!r} ({ct})")
+            # Navigate to a fresh form (keeps the session alive)
+            reset_page(driver, tool_url)
 
-            # Save image to a temp file (converts raster and vector formats to PNG as needed)
-            tmp_path = None
-            try:
-                tmp_path = save_image_to_temp(image.blob, ct)
+            # Upload and generate
+            raw_output = upload_and_generate(
+                driver, tmp_path,
+                purpose=purpose, includes=includes, tone=tone,
+            )
 
-                # Navigate to a fresh form (keeps the session alive)
-                reset_page(driver, tool_url)
+            # Extract the requested version
+            alt_text = extract_version(raw_output, version)
 
-                # Upload and generate
-                raw_output = upload_and_generate(
-                    driver, tmp_path,
-                    purpose=purpose, includes=includes, tone=tone,
-                )
-
-                # Extract the requested version
-                alt_text = extract_version(raw_output, version)
-
-                # Write into the PPTX XML
-                wrote = set_alt_text(shape, description=alt_text)
-                if wrote:
-                    preview = alt_text[:100] + ("…" if len(alt_text) > 100 else "")
-                    print(f"  OK — {preview}\n")
-                    ok += 1
-                else:
-                    print("  WARNING — could not locate cNvPr element; alt text not written.\n")
-                    errors += 1
-
-            except Exception as exc:
-                print(f"  ERROR — {exc}\n")
+            # Write into the PPTX XML
+            wrote = set_alt_text(shape, description=alt_text)
+            if wrote:
+                preview = alt_text[:100] + ("…" if len(alt_text) > 100 else "")
+                print(f"  OK — {preview}\n")
+                ok += 1
+            else:
+                print("  WARNING — could not locate cNvPr element; alt text not written.\n")
                 errors += 1
 
-            finally:
-                if tmp_path and tmp_path.exists():
-                    tmp_path.unlink(missing_ok=True)
+        except Exception as exc:
+            print(f"  ERROR — {exc}\n")
+            errors += 1
 
-        prs.save(output_path)
+        finally:
+            if tmp_path and tmp_path.exists():
+                tmp_path.unlink(missing_ok=True)
 
-    finally:
-        driver.quit()
+    prs.save(output_path)
 
     print("─" * 60)
     print(f"Total images : {len(images)}")
@@ -660,6 +660,36 @@ def process_presentation(
     print(f"  Skipped    : {skipped}")
     print(f"  Errors     : {errors}")
     print(f"Output saved : {output_path}")
+
+
+def process_presentation(
+    pptx_path: Path,
+    output_path: Path,
+    tool_url: str,
+    version: str,
+    browser: str,
+    geckodriver_path: Path | None,
+    purpose: str | None,
+    includes: list[str],
+    tone: str | None,
+    stop_event: threading.Event | None = None,
+) -> None:
+    driver = build_driver(browser, geckodriver_path)
+    try:
+        wait_for_auth(driver, tool_url)
+        run_batch(
+            driver=driver,
+            pptx_path=pptx_path,
+            output_path=output_path,
+            tool_url=tool_url,
+            version=version,
+            purpose=purpose,
+            includes=includes,
+            tone=tone,
+            stop_event=stop_event,
+        )
+    finally:
+        driver.quit()
 
 
 # ── entry point ───────────────────────────────────────────────────────────────

--- a/generate_alt_text.py
+++ b/generate_alt_text.py
@@ -31,7 +31,14 @@ from pathlib import Path
 
 try:
     from selenium import webdriver
-    from selenium.common.exceptions import SessionNotCreatedException, TimeoutException
+    from selenium.common.exceptions import (
+        InvalidSessionIdException,
+        NoSuchWindowException,
+        SessionNotCreatedException,
+        TimeoutException,
+    )
+    # Exceptions that mean the browser process is gone — not a per-image error
+    _SESSION_LOST_EXCEPTIONS = (InvalidSessionIdException, NoSuchWindowException)
     from selenium.webdriver.chrome.options import Options as ChromeOptions
     from selenium.webdriver.chrome.service import Service as ChromeService
     from selenium.webdriver.common.by import By
@@ -644,6 +651,8 @@ def run_batch(
                 print("  WARNING — could not locate cNvPr element; alt text not written.\n")
                 errors += 1
 
+        except _SESSION_LOST_EXCEPTIONS:
+            raise   # browser is gone — let the caller handle it
         except Exception as exc:
             print(f"  ERROR — {exc}\n")
             errors += 1

--- a/generate_alt_text.py
+++ b/generate_alt_text.py
@@ -23,6 +23,7 @@ import io
 import re
 import sys
 import tempfile
+import threading
 import time
 from pathlib import Path
 
@@ -577,6 +578,7 @@ def process_presentation(
     purpose: str | None,
     includes: list[str],
     tone: str | None,
+    stop_event: threading.Event | None = None,
 ) -> None:
     prs = Presentation(pptx_path)
 
@@ -603,6 +605,10 @@ def process_presentation(
         errors = 0
 
         for idx, (slide_num, shape) in enumerate(images, start=1):
+            if stop_event and stop_event.is_set():
+                print("\nAborted by user.\n")
+                break
+
             image = shape.image
             ct = image.content_type.lower()
 

--- a/gui.py
+++ b/gui.py
@@ -20,7 +20,9 @@ try:
         PURPOSE_OPTIONS,
         INCLUDE_OPTIONS,
         TONE_OPTIONS,
-        process_presentation,
+        build_driver,
+        wait_for_auth,
+        run_batch,
         _LOCAL_GECKODRIVER,
     )
 except ImportError as exc:
@@ -35,20 +37,37 @@ ctk.set_default_color_theme("blue")
 
 DEFAULT_URL = "https://aihelper.engin.umich.edu/alt-text-generator"
 
+# Status display values
+_S_LAUNCHING     = ("Launching browser…",    "gray")
+_S_WAITING       = ("Waiting for sign-in…",  "orange")
+_S_READY         = ("Signed in ✓",           "green")
+_S_DISCONNECTED  = ("Not connected",         "gray")
+_S_LOST          = ("Connection lost",       "#c0392b")
+_S_TIMEOUT       = ("Sign-in timed out",     "#c0392b")
+
 
 class App(ctk.CTk):
     def __init__(self):
         super().__init__()
         self.title("Alt Text Automation")
-        self.geometry("820x760")
-        self.minsize(640, 600)
+        self.geometry("820x800")
+        self.minsize(640, 640)
+
+        self._driver = None
+        self._connecting = False
+        self._stop_event = threading.Event()
+
         self._build_ui()
+        self.protocol("WM_DELETE_WINDOW", self._on_close)
+
+        # Auto-connect once the event loop is running
+        self.after(300, self._connect)
 
     # ── UI construction ───────────────────────────────────────────────────────
 
     def _build_ui(self):
         self.grid_columnconfigure(0, weight=1)
-        self.grid_rowconfigure(6, weight=1)   # log area stretches
+        self.grid_rowconfigure(7, weight=1)   # log area stretches
 
         PAD = {"padx": 16, "pady": (8, 0)}
 
@@ -185,15 +204,35 @@ class App(ctk.CTk):
             adv_frame, text="Browse…", width=90, command=self._browse_gecko
         ).grid(row=1, column=2, padx=(0, 12), pady=(4, 12))
 
+        # ── Browser status row ────────────────────────────────────────────────
+        status_frame = ctk.CTkFrame(self)
+        status_frame.grid(row=3, column=0, sticky="ew", padx=16, pady=(8, 0))
+        status_frame.grid_columnconfigure(1, weight=1)
+
+        ctk.CTkLabel(
+            status_frame, text="Browser:", font=ctk.CTkFont(weight="bold")
+        ).grid(row=0, column=0, sticky="w", padx=12, pady=10)
+
+        self.status_label = ctk.CTkLabel(status_frame, text=_S_DISCONNECTED[0],
+                                         text_color=_S_DISCONNECTED[1])
+        self.status_label.grid(row=0, column=1, sticky="w", padx=4, pady=10)
+
+        self.reconnect_btn = ctk.CTkButton(
+            status_frame, text="Reconnect", width=110,
+            command=self._connect,
+        )
+        self.reconnect_btn.grid(row=0, column=2, padx=(0, 12), pady=10)
+
         # ── Run / Stop buttons ────────────────────────────────────────────────
         btn_frame = ctk.CTkFrame(self, fg_color="transparent")
-        btn_frame.grid(row=3, column=0, padx=16, pady=12, sticky="ew")
+        btn_frame.grid(row=4, column=0, padx=16, pady=12, sticky="ew")
         btn_frame.grid_columnconfigure(0, weight=1)
         btn_frame.grid_columnconfigure(1, weight=0)
 
         self.run_btn = ctk.CTkButton(
             btn_frame, text="Run", height=42,
             font=ctk.CTkFont(size=14, weight="bold"),
+            state="disabled",
             command=self._run,
         )
         self.run_btn.grid(row=0, column=0, sticky="ew", padx=(0, 8))
@@ -209,12 +248,12 @@ class App(ctk.CTk):
 
         # ── Progress bar ──────────────────────────────────────────────────────
         self.progress = ctk.CTkProgressBar(self, mode="indeterminate")
-        self.progress.grid(row=4, column=0, padx=16, pady=(0, 4), sticky="ew")
+        self.progress.grid(row=5, column=0, padx=16, pady=(0, 4), sticky="ew")
         self.progress.set(0)
 
         # ── Log section ───────────────────────────────────────────────────────
         log_header = ctk.CTkFrame(self, fg_color="transparent")
-        log_header.grid(row=5, column=0, sticky="ew", padx=16, pady=(4, 0))
+        log_header.grid(row=6, column=0, sticky="ew", padx=16, pady=(4, 0))
         log_header.grid_columnconfigure(0, weight=1)
 
         ctk.CTkLabel(
@@ -226,7 +265,7 @@ class App(ctk.CTk):
         ).grid(row=0, column=1, sticky="e")
 
         self.log_box = ctk.CTkTextbox(self, state="disabled", wrap="word")
-        self.log_box.grid(row=6, column=0, sticky="nsew", padx=16, pady=(4, 16))
+        self.log_box.grid(row=7, column=0, sticky="nsew", padx=16, pady=(4, 16))
 
     # ── file dialogs ──────────────────────────────────────────────────────────
 
@@ -255,6 +294,86 @@ class App(ctk.CTk):
         )
         if path:
             self.gecko_var.set(path)
+
+    # ── browser connect / disconnect ──────────────────────────────────────────
+
+    def _geckodriver_path(self) -> Path | None:
+        gecko_str = self.gecko_var.get().strip()
+        if gecko_str:
+            return Path(gecko_str)
+        if _LOCAL_GECKODRIVER.exists():
+            return _LOCAL_GECKODRIVER
+        return None
+
+    def _connect(self):
+        if self._connecting:
+            return
+        self._connecting = True
+
+        # Close any existing browser first
+        if self._driver is not None:
+            try:
+                self._driver.quit()
+            except Exception:
+                pass
+            self._driver = None
+
+        self._set_status(*_S_LAUNCHING)
+        self.reconnect_btn.configure(state="disabled")
+        self.run_btn.configure(state="disabled")
+
+        browser    = self.browser_var.get()
+        geckodriver = self._geckodriver_path()
+        url        = self.url_var.get().strip() or DEFAULT_URL
+
+        threading.Thread(
+            target=self._connect_worker,
+            args=(browser, geckodriver, url),
+            daemon=True,
+        ).start()
+
+    def _connect_worker(self, browser, geckodriver, url):
+        class _GuiWriter(io.TextIOBase):
+            def __init__(self_, app):
+                self_._app = app
+            def write(self_, text):
+                if text:
+                    self_._app.after(0, self_._app._log, text)
+                return len(text)
+            def flush(self_):
+                pass
+
+        old_stdout = sys.stdout
+        sys.stdout = _GuiWriter(self)
+        try:
+            driver = build_driver(browser, geckodriver)
+            self._driver = driver
+            self.after(0, self._set_status, *_S_WAITING)
+            wait_for_auth(driver, url, raise_on_timeout=True)
+            self.after(0, self._on_connect_done, None)
+        except TimeoutError as exc:
+            self._driver = None
+            self.after(0, self._on_connect_done, str(exc), True)
+        except Exception as exc:
+            self._driver = None
+            self.after(0, self._on_connect_done, str(exc))
+        finally:
+            sys.stdout = old_stdout
+
+    def _on_connect_done(self, error: str | None, timed_out: bool = False):
+        self._connecting = False
+        self.reconnect_btn.configure(state="normal")
+        if error:
+            status = _S_TIMEOUT if timed_out else _S_LOST
+            self._set_status(*status)
+        else:
+            self._set_status(*_S_READY)
+            self.run_btn.configure(state="normal")
+
+    def _set_status(self, text: str, color: str):
+        self.status_label.configure(text=text, text_color=color)
+
+    # ── stop ──────────────────────────────────────────────────────────────────
 
     def _stop(self):
         self._stop_event.set()
@@ -296,7 +415,6 @@ class App(ctk.CTk):
 
         url     = self.url_var.get().strip() or DEFAULT_URL
         version = self.version_var.get()
-        browser = self.browser_var.get()
 
         purpose = self.purpose_var.get()
         purpose = None if purpose == "(none)" else purpose
@@ -310,57 +428,40 @@ class App(ctk.CTk):
         tone = self.tone_var.get()
         tone = None if tone == "(none)" else tone
 
-        gecko_str = self.gecko_var.get().strip()
-        if gecko_str:
-            geckodriver = Path(gecko_str)
-        elif _LOCAL_GECKODRIVER.exists():
-            geckodriver = _LOCAL_GECKODRIVER
-        else:
-            geckodriver = None
-
-        # Clear log
-        self.log_box.configure(state="normal")
-        self.log_box.delete("1.0", "end")
-        self.log_box.configure(state="disabled")
-
         self._stop_event = threading.Event()
         self.run_btn.configure(state="disabled", text="Running…")
         self.stop_btn.configure(state="normal")
+        self.reconnect_btn.configure(state="disabled")
         self.progress.start()
 
         threading.Thread(
             target=self._worker,
-            args=(input_path, output_path, url, version, browser,
-                  geckodriver, purpose, includes, tone),
+            args=(input_path, output_path, url, version, purpose, includes, tone),
             daemon=True,
         ).start()
 
-    def _worker(self, input_path, output_path, url, version,
-                browser, geckodriver, purpose, includes, tone):
-        """Background thread: redirect stdout → log box, then run the backend."""
+    def _worker(self, input_path, output_path, url, version, purpose, includes, tone):
+        """Background thread: redirect stdout → log box, then run the batch."""
 
         class _GuiWriter(io.TextIOBase):
             def __init__(self_, app):
                 self_._app = app
-
             def write(self_, text):
                 if text:
                     self_._app.after(0, self_._app._log, text)
                 return len(text)
-
             def flush(self_):
                 pass
 
         old_stdout = sys.stdout
         sys.stdout = _GuiWriter(self)
         try:
-            process_presentation(
+            run_batch(
+                driver=self._driver,
                 pptx_path=input_path,
                 output_path=output_path,
                 tool_url=url,
                 version=version,
-                browser=browser,
-                geckodriver_path=geckodriver,
                 purpose=purpose,
                 includes=includes,
                 tone=tone,
@@ -369,21 +470,49 @@ class App(ctk.CTk):
             aborted = self._stop_event.is_set()
             self.after(0, self._on_done, None, aborted)
         except Exception as exc:
-            self.after(0, self._on_done, str(exc), False)
+            # Check if the browser was closed externally
+            err = str(exc)
+            lost = any(k in err.lower() for k in ("webdriver", "session", "browser"))
+            self.after(0, self._on_done, err, False, lost)
         finally:
             sys.stdout = old_stdout
 
-    def _on_done(self, error: str | None, aborted: bool = False):
+    def _on_done(self, error: str | None, aborted: bool = False, connection_lost: bool = False):
         self.progress.stop()
         self.progress.set(0)
-        self.run_btn.configure(state="normal", text="Run")
         self.stop_btn.configure(state="disabled", text="Stop")
-        if error:
+        self.reconnect_btn.configure(state="normal")
+
+        if connection_lost:
+            self._driver = None
+            self._set_status(*_S_LOST)
+            self.run_btn.configure(state="disabled", text="Run")
+            messagebox.showerror(
+                "Connection lost",
+                "The browser session was lost.\n\nClick Reconnect to sign in again."
+            )
+        elif error:
+            self.run_btn.configure(state="normal", text="Run")
             messagebox.showerror("Error", error)
         elif aborted:
-            messagebox.showwarning("Aborted", "Processing was stopped. Any completed slides have been saved.")
+            self.run_btn.configure(state="normal", text="Run")
+            messagebox.showwarning(
+                "Aborted",
+                "Processing was stopped. Any completed slides have been saved."
+            )
         else:
+            self.run_btn.configure(state="normal", text="Run")
             messagebox.showinfo("Done", "Alt text generation complete!")
+
+    # ── window close ──────────────────────────────────────────────────────────
+
+    def _on_close(self):
+        if self._driver is not None:
+            try:
+                self._driver.quit()
+            except Exception:
+                pass
+        self.destroy()
 
 
 def main():

--- a/gui.py
+++ b/gui.py
@@ -470,9 +470,8 @@ class App(ctk.CTk):
             aborted = self._stop_event.is_set()
             self.after(0, self._on_done, None, aborted)
         except Exception as exc:
-            # Check if the browser was closed externally
             err = str(exc)
-            lost = any(k in err.lower() for k in ("webdriver", "session", "browser"))
+            lost = type(exc).__name__ in ("InvalidSessionIdException", "NoSuchWindowException")
             self.after(0, self._on_done, err, False, lost)
         finally:
             sys.stdout = old_stdout

--- a/gui.py
+++ b/gui.py
@@ -185,13 +185,27 @@ class App(ctk.CTk):
             adv_frame, text="Browse…", width=90, command=self._browse_gecko
         ).grid(row=1, column=2, padx=(0, 12), pady=(4, 12))
 
-        # ── Run button ────────────────────────────────────────────────────────
+        # ── Run / Stop buttons ────────────────────────────────────────────────
+        btn_frame = ctk.CTkFrame(self, fg_color="transparent")
+        btn_frame.grid(row=3, column=0, padx=16, pady=12, sticky="ew")
+        btn_frame.grid_columnconfigure(0, weight=1)
+        btn_frame.grid_columnconfigure(1, weight=0)
+
         self.run_btn = ctk.CTkButton(
-            self, text="Run", height=42,
+            btn_frame, text="Run", height=42,
             font=ctk.CTkFont(size=14, weight="bold"),
             command=self._run,
         )
-        self.run_btn.grid(row=3, column=0, padx=16, pady=12, sticky="ew")
+        self.run_btn.grid(row=0, column=0, sticky="ew", padx=(0, 8))
+
+        self.stop_btn = ctk.CTkButton(
+            btn_frame, text="Stop", height=42, width=100,
+            font=ctk.CTkFont(size=14, weight="bold"),
+            fg_color="#c0392b", hover_color="#922b21",
+            state="disabled",
+            command=self._stop,
+        )
+        self.stop_btn.grid(row=0, column=1, sticky="e")
 
         # ── Progress bar ──────────────────────────────────────────────────────
         self.progress = ctk.CTkProgressBar(self, mode="indeterminate")
@@ -233,6 +247,10 @@ class App(ctk.CTk):
         )
         if path:
             self.gecko_var.set(path)
+
+    def _stop(self):
+        self._stop_event.set()
+        self.stop_btn.configure(state="disabled", text="Stopping…")
 
     # ── logging ───────────────────────────────────────────────────────────────
 
@@ -292,7 +310,9 @@ class App(ctk.CTk):
         self.log_box.delete("1.0", "end")
         self.log_box.configure(state="disabled")
 
+        self._stop_event = threading.Event()
         self.run_btn.configure(state="disabled", text="Running…")
+        self.stop_btn.configure(state="normal")
         self.progress.start()
 
         threading.Thread(
@@ -331,19 +351,24 @@ class App(ctk.CTk):
                 purpose=purpose,
                 includes=includes,
                 tone=tone,
+                stop_event=self._stop_event,
             )
-            self.after(0, self._on_done, None)
+            aborted = self._stop_event.is_set()
+            self.after(0, self._on_done, None, aborted)
         except Exception as exc:
-            self.after(0, self._on_done, str(exc))
+            self.after(0, self._on_done, str(exc), False)
         finally:
             sys.stdout = old_stdout
 
-    def _on_done(self, error: str | None):
+    def _on_done(self, error: str | None, aborted: bool = False):
         self.progress.stop()
         self.progress.set(0)
         self.run_btn.configure(state="normal", text="Run")
+        self.stop_btn.configure(state="disabled", text="Stop")
         if error:
             messagebox.showerror("Error", error)
+        elif aborted:
+            messagebox.showwarning("Aborted", "Processing was stopped. Any completed slides have been saved.")
         else:
             messagebox.showinfo("Done", "Alt text generation complete!")
 

--- a/gui.py
+++ b/gui.py
@@ -170,7 +170,7 @@ class App(ctk.CTk):
         adv_frame.grid_columnconfigure(1, weight=1)
 
         ctk.CTkLabel(
-            adv_frame, text="Advanced", font=ctk.CTkFont(size=13, weight="bold")
+            adv_frame, text="Advanced (for Firefox only)", font=ctk.CTkFont(size=13, weight="bold")
         ).grid(row=0, column=0, columnspan=3, sticky="w", padx=12, pady=(10, 4))
 
         ctk.CTkLabel(adv_frame, text="Geckodriver path:").grid(
@@ -213,9 +213,17 @@ class App(ctk.CTk):
         self.progress.set(0)
 
         # ── Log section ───────────────────────────────────────────────────────
+        log_header = ctk.CTkFrame(self, fg_color="transparent")
+        log_header.grid(row=5, column=0, sticky="ew", padx=16, pady=(4, 0))
+        log_header.grid_columnconfigure(0, weight=1)
+
         ctk.CTkLabel(
-            self, text="Log", font=ctk.CTkFont(size=13, weight="bold")
-        ).grid(row=5, column=0, sticky="w", padx=16, pady=(4, 0))
+            log_header, text="Log", font=ctk.CTkFont(size=13, weight="bold")
+        ).grid(row=0, column=0, sticky="w")
+        ctk.CTkButton(
+            log_header, text="Clear", width=70, height=26,
+            command=self._clear_log,
+        ).grid(row=0, column=1, sticky="e")
 
         self.log_box = ctk.CTkTextbox(self, state="disabled", wrap="word")
         self.log_box.grid(row=6, column=0, sticky="nsew", padx=16, pady=(4, 16))
@@ -259,6 +267,11 @@ class App(ctk.CTk):
         self.log_box.configure(state="normal")
         self.log_box.insert("end", text)
         self.log_box.see("end")
+        self.log_box.configure(state="disabled")
+
+    def _clear_log(self):
+        self.log_box.configure(state="normal")
+        self.log_box.delete("1.0", "end")
         self.log_box.configure(state="disabled")
 
     # ── run orchestration ─────────────────────────────────────────────────────

--- a/gui.py
+++ b/gui.py
@@ -1,0 +1,357 @@
+#!/usr/bin/env python3
+"""
+gui.py  –  CustomTkinter front-end for generate_alt_text.py
+
+Usage:
+    python gui.py
+"""
+
+import io
+import sys
+import threading
+from pathlib import Path
+
+import customtkinter as ctk
+from tkinter import filedialog, messagebox
+
+# ── import the backend ────────────────────────────────────────────────────────
+try:
+    from generate_alt_text import (
+        PURPOSE_OPTIONS,
+        INCLUDE_OPTIONS,
+        TONE_OPTIONS,
+        process_presentation,
+        _LOCAL_GECKODRIVER,
+    )
+except ImportError as exc:
+    import tkinter as _tk
+    _tk.Tk().withdraw()
+    messagebox.showerror("Import error", str(exc))
+    sys.exit(1)
+
+# ── appearance ────────────────────────────────────────────────────────────────
+ctk.set_appearance_mode("system")
+ctk.set_default_color_theme("blue")
+
+DEFAULT_URL = "https://aihelper.engin.umich.edu/alt-text-generator"
+
+
+class App(ctk.CTk):
+    def __init__(self):
+        super().__init__()
+        self.title("Alt Text Automation")
+        self.geometry("820x760")
+        self.minsize(640, 600)
+        self._build_ui()
+
+    # ── UI construction ───────────────────────────────────────────────────────
+
+    def _build_ui(self):
+        self.grid_columnconfigure(0, weight=1)
+        self.grid_rowconfigure(6, weight=1)   # log area stretches
+
+        PAD = {"padx": 16, "pady": (8, 0)}
+
+        # ── Files section ─────────────────────────────────────────────────────
+        files_frame = ctk.CTkFrame(self)
+        files_frame.grid(row=0, column=0, sticky="ew", **PAD)
+        files_frame.grid_columnconfigure(1, weight=1)
+
+        ctk.CTkLabel(
+            files_frame, text="Files", font=ctk.CTkFont(size=13, weight="bold")
+        ).grid(row=0, column=0, columnspan=3, sticky="w", padx=12, pady=(10, 4))
+
+        # Input PPTX
+        ctk.CTkLabel(files_frame, text="Input PPTX:").grid(
+            row=1, column=0, sticky="w", padx=12, pady=4
+        )
+        self.input_var = ctk.StringVar()
+        ctk.CTkEntry(
+            files_frame, textvariable=self.input_var,
+            placeholder_text="Select a .pptx file…"
+        ).grid(row=1, column=1, sticky="ew", padx=8, pady=4)
+        ctk.CTkButton(
+            files_frame, text="Browse…", width=90, command=self._browse_input
+        ).grid(row=1, column=2, padx=(0, 12), pady=4)
+
+        # Output PPTX
+        ctk.CTkLabel(files_frame, text="Output PPTX:").grid(
+            row=2, column=0, sticky="w", padx=12, pady=4
+        )
+        self.output_var = ctk.StringVar()
+        ctk.CTkEntry(
+            files_frame, textvariable=self.output_var,
+            placeholder_text="(auto: <name>_alt_text.pptx)"
+        ).grid(row=2, column=1, sticky="ew", padx=8, pady=4)
+        ctk.CTkButton(
+            files_frame, text="Browse…", width=90, command=self._browse_output
+        ).grid(row=2, column=2, padx=(0, 12), pady=4)
+
+        # Tool URL
+        ctk.CTkLabel(files_frame, text="Tool URL:").grid(
+            row=3, column=0, sticky="w", padx=12, pady=(4, 12)
+        )
+        self.url_var = ctk.StringVar(value=DEFAULT_URL)
+        ctk.CTkEntry(files_frame, textvariable=self.url_var).grid(
+            row=3, column=1, columnspan=2, sticky="ew", padx=(8, 12), pady=(4, 12)
+        )
+
+        # ── Options section ───────────────────────────────────────────────────
+        opts_frame = ctk.CTkFrame(self)
+        opts_frame.grid(row=1, column=0, sticky="ew", padx=16, pady=(8, 0))
+        opts_frame.grid_columnconfigure((1, 3), weight=1)
+
+        ctk.CTkLabel(
+            opts_frame, text="Options", font=ctk.CTkFont(size=13, weight="bold")
+        ).grid(row=0, column=0, columnspan=4, sticky="w", padx=12, pady=(10, 4))
+
+        # Version
+        ctk.CTkLabel(opts_frame, text="Alt text version:").grid(
+            row=1, column=0, sticky="w", padx=12, pady=4
+        )
+        self.version_var = ctk.StringVar(value="long")
+        ctk.CTkSegmentedButton(
+            opts_frame, values=["short", "medium", "long"],
+            variable=self.version_var
+        ).grid(row=1, column=1, sticky="w", padx=8, pady=4)
+
+        # Browser
+        ctk.CTkLabel(opts_frame, text="Browser:").grid(
+            row=1, column=2, sticky="w", padx=(16, 4), pady=4
+        )
+        self.browser_var = ctk.StringVar(value="auto")
+        ctk.CTkOptionMenu(
+            opts_frame, values=["auto", "firefox", "chrome", "edge"],
+            variable=self.browser_var, width=120
+        ).grid(row=1, column=3, sticky="w", padx=(0, 12), pady=4)
+
+        # Purpose
+        ctk.CTkLabel(opts_frame, text="Purpose:").grid(
+            row=2, column=0, sticky="w", padx=12, pady=4
+        )
+        self.purpose_var = ctk.StringVar(value="(none)")
+        ctk.CTkOptionMenu(
+            opts_frame,
+            values=["(none)"] + list(PURPOSE_OPTIONS),
+            variable=self.purpose_var,
+            width=210,
+            dynamic_resizing=False,
+        ).grid(row=2, column=1, sticky="w", padx=8, pady=4)
+
+        # Tone
+        ctk.CTkLabel(opts_frame, text="Tone:").grid(
+            row=2, column=2, sticky="w", padx=(16, 4), pady=4
+        )
+        self.tone_var = ctk.StringVar(value="(none)")
+        ctk.CTkOptionMenu(
+            opts_frame,
+            values=["(none)"] + list(TONE_OPTIONS),
+            variable=self.tone_var,
+            width=150,
+            dynamic_resizing=False,
+        ).grid(row=2, column=3, sticky="w", padx=(0, 12), pady=4)
+
+        # Include checkboxes
+        ctk.CTkLabel(opts_frame, text="Include:").grid(
+            row=3, column=0, sticky="w", padx=12, pady=(4, 12)
+        )
+        self.include_data_var = ctk.BooleanVar(value=False)
+        self.include_captions_var = ctk.BooleanVar(value=False)
+        ctk.CTkCheckBox(
+            opts_frame, text="Data Values", variable=self.include_data_var
+        ).grid(row=3, column=1, sticky="w", padx=8, pady=(4, 12))
+        ctk.CTkCheckBox(
+            opts_frame, text="Captions / Labels", variable=self.include_captions_var
+        ).grid(row=3, column=2, columnspan=2, sticky="w", padx=(16, 12), pady=(4, 12))
+
+        # ── Advanced section ──────────────────────────────────────────────────
+        adv_frame = ctk.CTkFrame(self)
+        adv_frame.grid(row=2, column=0, sticky="ew", padx=16, pady=(8, 0))
+        adv_frame.grid_columnconfigure(1, weight=1)
+
+        ctk.CTkLabel(
+            adv_frame, text="Advanced", font=ctk.CTkFont(size=13, weight="bold")
+        ).grid(row=0, column=0, columnspan=3, sticky="w", padx=12, pady=(10, 4))
+
+        ctk.CTkLabel(adv_frame, text="Geckodriver path:").grid(
+            row=1, column=0, sticky="w", padx=12, pady=(4, 12)
+        )
+        self.gecko_var = ctk.StringVar()
+        ctk.CTkEntry(
+            adv_frame, textvariable=self.gecko_var,
+            placeholder_text="(auto-detect)"
+        ).grid(row=1, column=1, sticky="ew", padx=8, pady=(4, 12))
+        ctk.CTkButton(
+            adv_frame, text="Browse…", width=90, command=self._browse_gecko
+        ).grid(row=1, column=2, padx=(0, 12), pady=(4, 12))
+
+        # ── Run button ────────────────────────────────────────────────────────
+        self.run_btn = ctk.CTkButton(
+            self, text="Run", height=42,
+            font=ctk.CTkFont(size=14, weight="bold"),
+            command=self._run,
+        )
+        self.run_btn.grid(row=3, column=0, padx=16, pady=12, sticky="ew")
+
+        # ── Progress bar ──────────────────────────────────────────────────────
+        self.progress = ctk.CTkProgressBar(self, mode="indeterminate")
+        self.progress.grid(row=4, column=0, padx=16, pady=(0, 4), sticky="ew")
+        self.progress.set(0)
+
+        # ── Log section ───────────────────────────────────────────────────────
+        ctk.CTkLabel(
+            self, text="Log", font=ctk.CTkFont(size=13, weight="bold")
+        ).grid(row=5, column=0, sticky="w", padx=16, pady=(4, 0))
+
+        self.log_box = ctk.CTkTextbox(self, state="disabled", wrap="word")
+        self.log_box.grid(row=6, column=0, sticky="nsew", padx=16, pady=(4, 16))
+
+    # ── file dialogs ──────────────────────────────────────────────────────────
+
+    def _browse_input(self):
+        path = filedialog.askopenfilename(
+            filetypes=[("PowerPoint files", "*.pptx"), ("All files", "*.*")]
+        )
+        if path:
+            self.input_var.set(path)
+            # Auto-fill output only if still blank
+            if not self.output_var.get():
+                p = Path(path)
+                self.output_var.set(str(p.with_stem(p.stem + "_alt_text")))
+
+    def _browse_output(self):
+        path = filedialog.asksaveasfilename(
+            defaultextension=".pptx",
+            filetypes=[("PowerPoint files", "*.pptx"), ("All files", "*.*")],
+        )
+        if path:
+            self.output_var.set(path)
+
+    def _browse_gecko(self):
+        path = filedialog.askopenfilename(
+            filetypes=[("Executables", "*.exe geckodriver"), ("All files", "*.*")]
+        )
+        if path:
+            self.gecko_var.set(path)
+
+    # ── logging ───────────────────────────────────────────────────────────────
+
+    def _log(self, text: str):
+        """Append text to the log box. Must be called from the main thread."""
+        self.log_box.configure(state="normal")
+        self.log_box.insert("end", text)
+        self.log_box.see("end")
+        self.log_box.configure(state="disabled")
+
+    # ── run orchestration ─────────────────────────────────────────────────────
+
+    def _run(self):
+        # Validate input
+        input_str = self.input_var.get().strip()
+        if not input_str:
+            messagebox.showwarning("Missing input", "Please select an input PPTX file.")
+            return
+        input_path = Path(input_str)
+        if not input_path.exists():
+            messagebox.showerror("File not found", f"File not found:\n{input_path}")
+            return
+
+        output_str = self.output_var.get().strip()
+        output_path = (
+            Path(output_str)
+            if output_str
+            else input_path.with_stem(input_path.stem + "_alt_text")
+        )
+
+        url     = self.url_var.get().strip() or DEFAULT_URL
+        version = self.version_var.get()
+        browser = self.browser_var.get()
+
+        purpose = self.purpose_var.get()
+        purpose = None if purpose == "(none)" else purpose
+
+        includes = []
+        if self.include_data_var.get():
+            includes.append("data-values")
+        if self.include_captions_var.get():
+            includes.append("captions")
+
+        tone = self.tone_var.get()
+        tone = None if tone == "(none)" else tone
+
+        gecko_str = self.gecko_var.get().strip()
+        if gecko_str:
+            geckodriver = Path(gecko_str)
+        elif _LOCAL_GECKODRIVER.exists():
+            geckodriver = _LOCAL_GECKODRIVER
+        else:
+            geckodriver = None
+
+        # Clear log
+        self.log_box.configure(state="normal")
+        self.log_box.delete("1.0", "end")
+        self.log_box.configure(state="disabled")
+
+        self.run_btn.configure(state="disabled", text="Running…")
+        self.progress.start()
+
+        threading.Thread(
+            target=self._worker,
+            args=(input_path, output_path, url, version, browser,
+                  geckodriver, purpose, includes, tone),
+            daemon=True,
+        ).start()
+
+    def _worker(self, input_path, output_path, url, version,
+                browser, geckodriver, purpose, includes, tone):
+        """Background thread: redirect stdout → log box, then run the backend."""
+
+        class _GuiWriter(io.TextIOBase):
+            def __init__(self_, app):
+                self_._app = app
+
+            def write(self_, text):
+                if text:
+                    self_._app.after(0, self_._app._log, text)
+                return len(text)
+
+            def flush(self_):
+                pass
+
+        old_stdout = sys.stdout
+        sys.stdout = _GuiWriter(self)
+        try:
+            process_presentation(
+                pptx_path=input_path,
+                output_path=output_path,
+                tool_url=url,
+                version=version,
+                browser=browser,
+                geckodriver_path=geckodriver,
+                purpose=purpose,
+                includes=includes,
+                tone=tone,
+            )
+            self.after(0, self._on_done, None)
+        except Exception as exc:
+            self.after(0, self._on_done, str(exc))
+        finally:
+            sys.stdout = old_stdout
+
+    def _on_done(self, error: str | None):
+        self.progress.stop()
+        self.progress.set(0)
+        self.run_btn.configure(state="normal", text="Run")
+        if error:
+            messagebox.showerror("Error", error)
+        else:
+            messagebox.showinfo("Done", "Alt text generation complete!")
+
+
+def main():
+    app = App()
+    app.mainloop()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
# Summary
Adds gui.py, a CustomTkinter desktop front-end for generate_alt_text.py that exposes all CLI options as form controls
Refactors generate_alt_text.py to expose run_batch() (processing loop only) separately from browser lifecycle, enabling the GUI to reuse a single authenticated session across multiple PPTX files
Updates README.md with GUI usage instructions and the customtkinter dependency

# Details
## GUI (gui.py)
The GUI is intended as the primary way to use the tool for users who would otherwise run it repeatedly. Key behaviors:

- Auto-connect on startup — the browser launches and navigates to the tool as soon as the window opens, so sign-in is ready before the user has finished selecting a file
- Persistent session — the browser stays open after each run; subsequent PPTX files can be processed without re-authenticating
- Reconnect — if the browser is closed or the session is lost, a status indicator updates to reflect this and a Reconnect button re-launches the browser
- Graceful abort — a Stop button signals the processing loop to halt after the current image; slides completed so far are saved
- Live log — stdout from the backend streams into a scrollable log area in real time, with a Clear button

## Backend refactor (generate_alt_text.py)
- run_batch(driver, ...) — new function containing the processing loop; accepts an existing, already-authenticated driver
- process_presentation(...) — unchanged from the caller's perspective; now a thin wrapper around build_driver → wait_for_auth → run_batch → driver.quit()
- wait_for_auth(...) — accepts raise_on_timeout=True so the GUI can handle a sign-in timeout gracefully rather than receiving a sys.exit() call